### PR TITLE
Remove Raw HEX mode and keep CAN decode only

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,7 +4,6 @@
 #include <QGroupBox>
 #include <QGridLayout>
 #include <QHeaderView>
-#include <QListWidget>
 #include <QLabel>
 #include <QDateTime>
 #include <QThread>
@@ -22,20 +21,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     spinSamples->setRange(1, 1000000000);
     spinSamples->setValue(1000000);
 
-    listChannels = new QListWidget();
-    listChannels->setSelectionMode(QAbstractItemView::NoSelection);
-    for (const auto &ch : allCh()) {
-        auto *it = new QListWidgetItem(ch);
-        it->setCheckState(ch=="CH0" ? Qt::Checked : Qt::Unchecked);
-        listChannels->addItem(it);
-    }
-
-    comboMode = new QComboBox();
-    comboMode->addItem("Raw HEX");
-    comboMode->addItem("CAN Decode");
-    connect(comboMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, &MainWindow::onModeChanged);
-
     comboCanRx = new QComboBox();
     comboCanRx->addItems(allCh());
     comboCanRx->setCurrentText("CH0");
@@ -47,7 +32,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     btnStop  = new QPushButton("Stop");
     btnStop->setEnabled(false);
 
-    txtRaw = new QTextEdit(); txtRaw->setReadOnly(true);
     txtLog = new QTextEdit(); txtLog->setReadOnly(true);
 
     tblCan = new QTableWidget(0, 5);
@@ -68,16 +52,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 
     auto *gbCap = new QGroupBox("Capture");
     auto *capLay = new QGridLayout();
-    capLay->addWidget(new QLabel("Mode:"),0,0);
-    capLay->addWidget(comboMode,0,1);
-    capLay->addWidget(new QLabel("Channels (Raw HEX):"),1,0,1,2);
-    capLay->addWidget(listChannels,2,0,1,2);
-    capLay->addWidget(new QLabel("CAN RX:"),3,0);
-    capLay->addWidget(comboCanRx,3,1);
-    capLay->addWidget(new QLabel("Nominal bitrate:"),4,0);
-    capLay->addWidget(editCanBitrate,4,1);
-    capLay->addWidget(new QLabel("Sample point (%):"),5,0);
-    capLay->addWidget(editSamplePoint,5,1);
+    capLay->addWidget(new QLabel("CAN RX:"),0,0);
+    capLay->addWidget(comboCanRx,0,1);
+    capLay->addWidget(new QLabel("Nominal bitrate:"),1,0);
+    capLay->addWidget(editCanBitrate,1,1);
+    capLay->addWidget(new QLabel("Sample point (%):"),2,0);
+    capLay->addWidget(editSamplePoint,2,1);
     gbCap->setLayout(capLay);
 
     auto *gbCtrl = new QGroupBox("Controls");
@@ -93,11 +73,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     left->addWidget(gbCtrl);
     left->addStretch();
 
-    auto *gbRaw = new QGroupBox("Raw HEX");
-    auto *rawLay = new QVBoxLayout();
-    rawLay->addWidget(txtRaw);
-    gbRaw->setLayout(rawLay);
-
     auto *gbCan = new QGroupBox("CAN Frames");
     auto *canLay = new QVBoxLayout();
     canLay->addWidget(tblCan);
@@ -109,8 +84,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     gbLog->setLayout(logLay);
 
     auto *right = new QVBoxLayout();
-    right->addWidget(gbRaw, 2);
-    right->addWidget(gbCan, 2);
+    right->addWidget(gbCan, 3);
     right->addWidget(gbLog, 1);
 
     auto *central = new QWidget();
@@ -122,30 +96,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 
     connect(btnStart, &QPushButton::clicked, this, &MainWindow::onStart);
     connect(btnStop,  &QPushButton::clicked, this, &MainWindow::onStop);
-
-    onModeChanged(comboMode->currentIndex());
 }
 
 MainWindow::~MainWindow() {
     onStop();
 }
 
-MainWindow::Mode MainWindow::mode() const {
-    return comboMode->currentIndex() == 1 ? Mode::CanDecode : Mode::RawHex;
-}
-
-void MainWindow::onModeChanged(int idx) {
-    bool isCan = (idx==1);
-    listChannels->setEnabled(!isCan);
-    comboCanRx->setEnabled(isCan);
-    editCanBitrate->setEnabled(isCan);
-    editSamplePoint->setEnabled(isCan);
-}
-
 void MainWindow::onStart() {
     btnStart->setEnabled(false);
     btnStop->setEnabled(true);
-    txtRaw->clear();
     txtLog->clear();
     tblCan->setRowCount(0);
 
@@ -157,29 +116,15 @@ void MainWindow::onStart() {
     worker->setDeviceDriver(editDriver->text().trimmed());
     worker->setSamplerate(editSamplerate->text().trimmed().toULongLong());
     worker->setLimitSamples(spinSamples->value());
-
-    if (mode() == Mode::RawHex) {
-        QStringList chs;
-        for (int i=0;i<listChannels->count();++i) {
-            if (listChannels->item(i)->checkState()==Qt::Checked)
-                chs << listChannels->item(i)->text();
-        }
-        worker->setChannels(chs);
-        worker->setCanMode(false);
-    } else {
-        worker->setChannels(QStringList() << comboCanRx->currentText());
-        worker->setCanMode(true);
-        worker->setCanParams(comboCanRx->currentText(),
-                             editCanBitrate->text().trimmed().toUInt(),
-                             editSamplePoint->text().trimmed().toDouble());
-    }
+    worker->setChannels(QStringList() << comboCanRx->currentText());
+    worker->setCanParams(editCanBitrate->text().trimmed().toUInt(),
+                         editSamplePoint->text().trimmed().toDouble());
 
     workerThread = new QThread(this);
     worker->moveToThread(workerThread);
 
     connect(workerThread, &QThread::started, worker, &SigrokWorker::start);
     connect(worker, &SigrokWorker::finished, this, &MainWindow::onFinished);
-    connect(worker, &SigrokWorker::rawLineReady, this, &MainWindow::onRawLine);
     connect(worker, &SigrokWorker::canFrameReady, this, &MainWindow::onCanFrame);
     connect(worker, &SigrokWorker::logMsg, this, &MainWindow::onLog);
 
@@ -200,10 +145,6 @@ void MainWindow::onStop() {
         workerThread = nullptr;
         worker = nullptr;
     }
-}
-
-void MainWindow::onRawLine(const QString &line) {
-    txtRaw->append(line);
 }
 
 void MainWindow::onCanFrame(const CanFrame &f) {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -6,8 +6,7 @@
 #include <QSpinBox>
 #include <QComboBox>
 #include <QPushButton>
-#include <QCheckBox>
-#include <QListWidget>
+#include <QThread>
 #include "sigrokworker.h"
 
 class MainWindow : public QMainWindow {
@@ -19,23 +18,14 @@ public:
 private slots:
     void onStart();
     void onStop();
-    void onRawLine(const QString &line);
     void onCanFrame(const CanFrame &f);
     void onLog(const QString &msg);
     void onFinished(int code);
-    void onModeChanged(int);
-
-private:
-    enum class Mode { RawHex, CanDecode };
-    Mode mode() const;
 
 private:
     QLineEdit *editDriver;
     QLineEdit *editSamplerate;
     QSpinBox  *spinSamples;
-    QListWidget *listChannels;
-
-    QComboBox *comboMode;
     QComboBox *comboCanRx;
     QLineEdit *editCanBitrate;
     QLineEdit *editSamplePoint;
@@ -43,7 +33,6 @@ private:
     QPushButton *btnStart;
     QPushButton *btnStop;
 
-    QTextEdit *txtRaw;
     QTextEdit *txtLog;
     QTableWidget *tblCan;
 

--- a/sigrokworker.cpp
+++ b/sigrokworker.cpp
@@ -14,9 +14,8 @@ void SigrokWorker::setDeviceDriver(const QString &drv) { driverName_ = drv; }
 void SigrokWorker::setSamplerate(uint64_t sr) { samplerate_ = sr; }
 void SigrokWorker::setLimitSamples(uint64_t n) { limitSamples_ = n; }
 void SigrokWorker::setChannels(const QStringList &chs) { enabledChs_ = chs; }
-void SigrokWorker::setCanMode(bool e) { canMode_ = e; }
-void SigrokWorker::setCanParams(const QString &rxCh, uint32_t nominal_bitrate, double sample_point) {
-    canRx_ = rxCh; canNominalBitrate_ = nominal_bitrate; canSamplePoint_ = sample_point;
+void SigrokWorker::setCanParams(uint32_t nominal_bitrate, double sample_point) {
+    canNominalBitrate_ = nominal_bitrate; canSamplePoint_ = sample_point;
 }
 
 void SigrokWorker::start() {
@@ -178,64 +177,34 @@ void SigrokWorker::datafeedCb(const struct sr_dev_inst*,
 void SigrokWorker::handleLogicPacket(const struct sr_datafeed_logic *logic) {
     if (!logic || !logic->data || logic->length == 0) return;
 
-    const uint8_t *buf = static_cast<const uint8_t*>(logic->data);
-    const size_t nbytes = logic->length;
     if (logic->unitsize != 1) {
         emit logMsg("Unexpected unitsize != 1; skipping.");
         return;
     }
 
 #ifdef SRD_HEADER
-    if (canMode_) {
-        srdFeed(logic);
-    }
+    srdFeed(logic);
 #endif
-
-    for (int chIdx : activeLogicIdx_) {
-        QString line = QString("CH%1: ").arg(chIdx);
-        uint8_t acc = 0;
-        int bitpos = 0;
-        for (size_t i = 0; i < nbytes; ++i) {
-            const uint8_t v = buf[i];
-            const uint8_t bit = (v >> chIdx) & 0x1;
-            acc |= (bit & 0x1) << bitpos;
-            bitpos++;
-            if (bitpos == 8) {
-                line += QString("%1 ").arg(acc, 2, 16, QLatin1Char('0')).toUpper();
-                bitpos = 0;
-                acc = 0;
-            }
-        }
-        if (bitpos != 0) {
-            line += QString("%1 ").arg(acc, 2, 16, QLatin1Char('0')).toUpper();
-        }
-        emit rawLineReady(line.trimmed());
-    }
 }
 
 #ifdef SRD_HEADER
 void SigrokWorker::srdInitIfNeeded() {
-    if (!canMode_) return;
     if (srd_init(nullptr) != SRD_OK) {
         emit logMsg("srd_init failed; CAN decode disabled.");
-        canMode_ = false;
         return;
     }
     if (srd_session_new(&srd_sess_) != SRD_OK) {
         emit logMsg("srd_session_new failed; CAN decode disabled.");
-        canMode_ = false;
         return;
     }
     srd_decoder_load_all();
     srd_can_dec_ = srd_decoder_by_id("can");
     if (!srd_can_dec_) {
         emit logMsg("CAN decoder not found in libsigrokdecode.");
-        canMode_ = false;
         return;
     }
     if (srd_inst_new(&srd_can_inst_, srd_can_dec_, srd_sess_) != SRD_OK) {
         emit logMsg("srd_inst_new failed; CAN decode disabled.");
-        canMode_ = false;
         return;
     }
     srd_inst_option_set(srd_can_inst_, "nominal_bitrate", canNominalBitrate_);

--- a/sigrokworker.h
+++ b/sigrokworker.h
@@ -34,11 +34,9 @@ public:
     void setSamplerate(uint64_t sr_hz);
     void setLimitSamples(uint64_t n);
     void setChannels(const QStringList &chs);
-    void setCanMode(bool enable);
-    void setCanParams(const QString &rxCh, uint32_t nominal_bitrate, double sample_point = 80.0);
+    void setCanParams(uint32_t nominal_bitrate, double sample_point = 80.0);
 
 signals:
-    void rawLineReady(const QString &line);
     void canFrameReady(const CanFrame &f);
     void logMsg(const QString &msg);
     void finished(int code);
@@ -63,9 +61,6 @@ private:
     uint64_t samplerate_ = 10'000'000;
     uint64_t limitSamples_ = 1'000'000;
     QStringList enabledChs_ = {"CH0"};
-
-    bool canMode_ = false;
-    QString canRx_ = "CH0";
     uint32_t canNominalBitrate_ = 500000;
     double canSamplePoint_ = 80.0;
 


### PR DESCRIPTION
## Summary
- Simplify the GUI and capture logic to only support CAN decoding
- Drop Raw HEX output and related signals from SigrokWorker
- Include QThread header in MainWindow

## Testing
- `qmake -v` *(fails: command not found)*
- `make -C build/Desktop_Qt_5_15_2_MinGW_32_bit-Debug` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7695e2ac83308ffdc87894bf1c09