### PR TITLE
docs: recommend separate build dirs for MinGW kits

### DIFF
--- a/SigrokHexViewer.txt
+++ b/SigrokHexViewer.txt
@@ -1,3 +1,7 @@
+# When switching between MinGW 32-bit and 64-bit kits,
+# use a separate build directory or clean the existing
+# build directory before rebuilding to avoid architecture
+# mismatches.
 QT       += core gui
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += core gui widgets


### PR DESCRIPTION
## Summary
- advise cleaning or using separate build dirs when switching between MinGW 32- and 64-bit kits

## Testing
- `make -n` (fails: Makefile:73: *** multiple target patterns.  Stop.)

------
https://chatgpt.com/codex/tasks/task_e_68aec6504d188330ac6a6f5906af76fb